### PR TITLE
Add corpus-embedded search telemetry foundation

### DIFF
--- a/src/features/corpus/lib/normalizeCorpus.ts
+++ b/src/features/corpus/lib/normalizeCorpus.ts
@@ -1,6 +1,7 @@
-import type { CorpusEntry, CorpusFile, EntryBody } from '../model/types';
+import type { CorpusEntry, CorpusFile, CorpusInput, EntryBody } from '../model/types';
 import { createId } from '../../../shared/lib/ids';
 import { normalizeTags } from '../../tags/lib/normalizeTags';
+import { normalizeSearchMetrics } from './searchMetrics';
 
 function normalizeBody(body: EntryBody | undefined): EntryBody {
   return {
@@ -26,13 +27,16 @@ function normalizeEntry(entry: CorpusEntry): CorpusEntry {
   };
 }
 
-export function normalizeCorpus(corpus: CorpusFile): CorpusFile {
+export function normalizeCorpus(corpus: CorpusInput): CorpusFile {
+  const entries = corpus.entries.map(normalizeEntry);
+
   return {
-    version: '1.1',
+    version: '1.2',
     owner: {
       name: corpus.owner.name?.trim() || undefined,
       team: corpus.owner.team?.trim() || 'IT Support',
     },
-    entries: corpus.entries.map(normalizeEntry),
+    entries,
+    searchMetrics: normalizeSearchMetrics('searchMetrics' in corpus ? corpus.searchMetrics : undefined, entries.map((entry) => entry.id)),
   };
 }

--- a/src/features/corpus/lib/openArticleInNewTab.ts
+++ b/src/features/corpus/lib/openArticleInNewTab.ts
@@ -1,5 +1,6 @@
 import type { CorpusEntry } from '../model/types';
 import { contentToPlainText } from '../../editor/lib/blockTransforms';
+import { ARTICLE_TELEMETRY_CHANNEL } from './searchMetrics';
 
 function escapeHtml(value: string) {
   return value
@@ -57,7 +58,81 @@ function renderBlocks(entry: CorpusEntry) {
     .join('');
 }
 
-export function openArticleInNewTab(entry: CorpusEntry) {
+function serializeScriptLiteral(value: string) {
+  return JSON.stringify(value).replaceAll('</', '<\\/');
+}
+
+function buildTelemetryScript(entryId: string, corpusName: string) {
+  return `<script>
+(() => {
+  const payload = {
+    entryId: ${serializeScriptLiteral(entryId)},
+    corpusName: ${serializeScriptLiteral(corpusName)},
+    channelName: ${serializeScriptLiteral(ARTICLE_TELEMETRY_CHANNEL)}
+  };
+  if (typeof BroadcastChannel === 'undefined') {
+    return;
+  }
+
+  const channel = new BroadcastChannel(payload.channelName);
+  let visibleDwellMs = 0;
+  let activeStartedAt = null;
+  let finalized = false;
+
+  const isActive = () => document.visibilityState === 'visible' && document.hasFocus();
+  const resume = () => {
+    if (activeStartedAt !== null || !isActive()) {
+      return;
+    }
+
+    activeStartedAt = Date.now();
+  };
+  const pause = () => {
+    if (activeStartedAt === null) {
+      return;
+    }
+
+    visibleDwellMs += Date.now() - activeStartedAt;
+    activeStartedAt = null;
+  };
+  const finalize = () => {
+    if (finalized) {
+      return;
+    }
+
+    pause();
+    finalized = true;
+    channel.postMessage({
+      type: 'session',
+      corpusName: payload.corpusName,
+      entryId: payload.entryId,
+      session: {
+        visibleDwellMs,
+        completedAt: new Date().toISOString()
+      }
+    });
+    channel.close();
+  };
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      resume();
+      return;
+    }
+
+    pause();
+  });
+  window.addEventListener('focus', resume);
+  window.addEventListener('blur', pause);
+  window.addEventListener('pagehide', finalize, { once: true });
+  window.addEventListener('beforeunload', finalize, { once: true });
+
+  resume();
+})();
+</script>`;
+}
+
+export function openArticleInNewTab(entry: CorpusEntry, corpusName: string) {
   const html = `<!doctype html>
 <html lang="en">
 <head>
@@ -91,6 +166,7 @@ export function openArticleInNewTab(entry: CorpusEntry) {
     <div class="chips">${entry.tags.map((tag) => `<span>${escapeHtml(tag)}</span>`).join('')}</div>
     ${renderBlocks(entry)}
   </main>
+  ${buildTelemetryScript(entry.id, corpusName)}
 </body>
 </html>`;
 

--- a/src/features/corpus/lib/searchMetrics.ts
+++ b/src/features/corpus/lib/searchMetrics.ts
@@ -1,0 +1,136 @@
+import type { CorpusFile, SearchMetricEntry, SearchMetrics } from '../model/types';
+
+export const ARTICLE_TELEMETRY_CHANNEL = 'latticekb:article-telemetry';
+export const MINIMUM_RECORDED_SESSION_MS = 1_000;
+export const SHORT_ABANDON_THRESHOLD_MS = 8_000;
+export const QUALIFIED_VIEW_THRESHOLD_MS = 10_000;
+export const LONG_VIEW_THRESHOLD_MS = 60_000;
+
+export type ArticleReadSession = {
+  visibleDwellMs: number;
+  completedAt: string;
+};
+
+export type ArticleTelemetryMessage =
+  | {
+      type: 'session';
+      corpusName: string;
+      entryId: string;
+      session: ArticleReadSession;
+    };
+
+export function createEmptySearchMetricEntry(): SearchMetricEntry {
+  return {
+    openCount: 0,
+    qualifiedViewCount: 0,
+    shortAbandonCount: 0,
+    totalQualifiedDwellSeconds: 0,
+    longViewCount: 0,
+    lastViewedAt: undefined,
+  };
+}
+
+export function createEmptySearchMetrics(): SearchMetrics {
+  return {
+    entries: {},
+  };
+}
+
+export function normalizeSearchMetricEntry(candidate: Partial<SearchMetricEntry> | undefined): SearchMetricEntry {
+  return {
+    openCount: Math.max(0, Math.trunc(candidate?.openCount ?? 0)),
+    qualifiedViewCount: Math.max(0, Math.trunc(candidate?.qualifiedViewCount ?? 0)),
+    shortAbandonCount: Math.max(0, Math.trunc(candidate?.shortAbandonCount ?? 0)),
+    totalQualifiedDwellSeconds: Math.max(0, Math.trunc(candidate?.totalQualifiedDwellSeconds ?? 0)),
+    longViewCount: Math.max(0, Math.trunc(candidate?.longViewCount ?? 0)),
+    lastViewedAt: typeof candidate?.lastViewedAt === 'string' && candidate.lastViewedAt ? candidate.lastViewedAt : undefined,
+  };
+}
+
+export function normalizeSearchMetrics(searchMetrics: SearchMetrics | undefined, validEntryIds: Iterable<string>): SearchMetrics {
+  const allowedIds = new Set(validEntryIds);
+  const normalizedEntries = Object.entries(searchMetrics?.entries ?? {}).reduce<Record<string, SearchMetricEntry>>((accumulator, [entryId, metrics]) => {
+    if (!allowedIds.has(entryId)) {
+      return accumulator;
+    }
+
+    accumulator[entryId] = normalizeSearchMetricEntry(metrics);
+    return accumulator;
+  }, {});
+
+  return {
+    entries: normalizedEntries,
+  };
+}
+
+function hasEntry(corpus: CorpusFile, entryId: string) {
+  return corpus.entries.some((entry) => entry.id === entryId);
+}
+
+function updateEntryMetrics(corpus: CorpusFile, entryId: string, updater: (metrics: SearchMetricEntry) => SearchMetricEntry): CorpusFile {
+  if (!hasEntry(corpus, entryId)) {
+    return corpus;
+  }
+
+  const currentMetrics = corpus.searchMetrics.entries[entryId] ?? createEmptySearchMetricEntry();
+  return {
+    ...corpus,
+    searchMetrics: {
+      entries: {
+        ...corpus.searchMetrics.entries,
+        [entryId]: updater(currentMetrics),
+      },
+    },
+  };
+}
+
+export function recordArticleOpen(corpus: CorpusFile, entryId: string): CorpusFile {
+  return updateEntryMetrics(corpus, entryId, (metrics) => ({
+    ...metrics,
+    openCount: metrics.openCount + 1,
+  }));
+}
+
+export function recordArticleReadSession(corpus: CorpusFile, entryId: string, session: ArticleReadSession): CorpusFile {
+  if (session.visibleDwellMs < MINIMUM_RECORDED_SESSION_MS) {
+    return corpus;
+  }
+
+  return updateEntryMetrics(corpus, entryId, (metrics) => {
+    const nextMetrics: SearchMetricEntry = {
+      ...metrics,
+      lastViewedAt: session.completedAt,
+    };
+
+    if (session.visibleDwellMs < SHORT_ABANDON_THRESHOLD_MS) {
+      nextMetrics.shortAbandonCount += 1;
+      return nextMetrics;
+    }
+
+    if (session.visibleDwellMs >= QUALIFIED_VIEW_THRESHOLD_MS) {
+      nextMetrics.qualifiedViewCount += 1;
+      nextMetrics.totalQualifiedDwellSeconds += Math.round(session.visibleDwellMs / 1_000);
+    }
+
+    if (session.visibleDwellMs >= LONG_VIEW_THRESHOLD_MS) {
+      nextMetrics.longViewCount += 1;
+    }
+
+    return nextMetrics;
+  });
+}
+
+export function isArticleTelemetryMessage(candidate: unknown): candidate is ArticleTelemetryMessage {
+  if (typeof candidate !== 'object' || candidate === null) {
+    return false;
+  }
+
+  const message = candidate as Partial<ArticleTelemetryMessage>;
+  return message.type === 'session'
+    && typeof message.corpusName === 'string'
+    && typeof message.entryId === 'string'
+    && typeof message.session === 'object'
+    && message.session !== null
+    && typeof message.session.visibleDwellMs === 'number'
+    && typeof message.session.completedAt === 'string';
+}

--- a/src/features/corpus/lib/validators.ts
+++ b/src/features/corpus/lib/validators.ts
@@ -1,8 +1,8 @@
 import { ZodError } from 'zod';
 import { corpusSchema } from '../model/schema';
-import type { CorpusFile } from '../model/types';
+import type { CorpusInput } from '../model/types';
 
-export function validateCorpus(candidate: unknown): CorpusFile {
+export function validateCorpus(candidate: unknown): CorpusInput {
   try {
     return corpusSchema.parse(candidate);
   } catch (error) {

--- a/src/features/corpus/model/sampleCorpus.ts
+++ b/src/features/corpus/model/sampleCorpus.ts
@@ -4,7 +4,7 @@ import { createId } from '../../../shared/lib/ids';
 const now = new Date().toISOString();
 
 export const sampleCorpus: CorpusFile = {
-  version: '1.1',
+  version: '1.2',
   owner: {
     name: 'LatticeKB Demo',
     team: 'IT Support',
@@ -119,4 +119,7 @@ export const sampleCorpus: CorpusFile = {
       },
     },
   ],
+  searchMetrics: {
+    entries: {},
+  },
 };

--- a/src/features/corpus/model/schema.ts
+++ b/src/features/corpus/model/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { CorpusInput } from './types';
 
 const storedBlockSchema = z.record(z.string(), z.unknown());
 
@@ -21,11 +22,34 @@ export const corpusEntrySchema = z.object({
   body: entryBodySchema,
 });
 
-export const corpusSchema = z.object({
-  version: z.literal('1.1'),
+export const searchMetricEntrySchema = z.object({
+  openCount: z.number().int().nonnegative().default(0),
+  qualifiedViewCount: z.number().int().nonnegative().default(0),
+  shortAbandonCount: z.number().int().nonnegative().default(0),
+  totalQualifiedDwellSeconds: z.number().int().nonnegative().default(0),
+  longViewCount: z.number().int().nonnegative().default(0),
+  lastViewedAt: z.string().datetime({ offset: true }).optional(),
+});
+
+export const searchMetricsSchema = z.object({
+  entries: z.record(z.string(), searchMetricEntrySchema).default({}),
+});
+
+const corpusBaseSchema = z.object({
   owner: z.object({
     name: z.string().optional(),
     team: z.string().optional(),
   }),
   entries: z.array(corpusEntrySchema),
 });
+
+const legacyCorpusSchema = corpusBaseSchema.extend({
+  version: z.literal('1.1'),
+});
+
+const currentCorpusSchema = corpusBaseSchema.extend({
+  version: z.literal('1.2'),
+  searchMetrics: searchMetricsSchema,
+});
+
+export const corpusSchema = z.union([legacyCorpusSchema, currentCorpusSchema]) satisfies z.ZodType<CorpusInput>;

--- a/src/features/corpus/model/types.ts
+++ b/src/features/corpus/model/types.ts
@@ -1,4 +1,4 @@
-export type CorpusVersion = '1.1';
+export type CorpusVersion = '1.1' | '1.2';
 
 export type StoredBlock = Record<string, unknown>;
 
@@ -21,16 +21,39 @@ export type CorpusEntry = {
   body: EntryBody;
 };
 
+export type SearchMetricEntry = {
+  openCount: number;
+  qualifiedViewCount: number;
+  shortAbandonCount: number;
+  totalQualifiedDwellSeconds: number;
+  longViewCount: number;
+  lastViewedAt?: string;
+};
+
+export type SearchMetrics = {
+  entries: Record<string, SearchMetricEntry>;
+};
+
 export type CorpusOwner = {
   name?: string;
   team?: string;
 };
 
-export type CorpusFile = {
-  version: CorpusVersion;
+type CorpusBase = {
   owner: CorpusOwner;
   entries: CorpusEntry[];
 };
+
+export type LegacyCorpusFile = CorpusBase & {
+  version: '1.1';
+};
+
+export type CorpusFile = CorpusBase & {
+  version: '1.2';
+  searchMetrics: SearchMetrics;
+};
+
+export type CorpusInput = LegacyCorpusFile | CorpusFile;
 
 export type ImportedCorpus = {
   corpus: CorpusFile;

--- a/src/features/persistence/lib/browserDatabase.ts
+++ b/src/features/persistence/lib/browserDatabase.ts
@@ -1,0 +1,23 @@
+export const LATTICE_DATABASE_NAME = 'latticekb';
+export const LATTICE_DATABASE_VERSION = 2;
+export const DRAFT_STORE_NAME = 'drafts';
+export const WORKSPACE_STORE_NAME = 'workspace';
+
+function ensureStore(database: IDBDatabase, storeName: string) {
+  if (!database.objectStoreNames.contains(storeName)) {
+    database.createObjectStore(storeName);
+  }
+}
+
+export function openLatticeDatabase() {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(LATTICE_DATABASE_NAME, LATTICE_DATABASE_VERSION);
+    request.onerror = () => reject(new Error('Unable to open browser persistence.'));
+    request.onupgradeneeded = () => {
+      const database = request.result;
+      ensureStore(database, DRAFT_STORE_NAME);
+      ensureStore(database, WORKSPACE_STORE_NAME);
+    };
+    request.onsuccess = () => resolve(request.result);
+  });
+}

--- a/src/features/persistence/lib/draftStore.ts
+++ b/src/features/persistence/lib/draftStore.ts
@@ -1,48 +1,31 @@
 import type { CorpusEntry } from '../../corpus/model/types';
-
-const DATABASE_NAME = 'latticekb';
-const STORE_NAME = 'drafts';
-const DATABASE_VERSION = 1;
-
-function openDatabase() {
-  return new Promise<IDBDatabase>((resolve, reject) => {
-    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
-    request.onerror = () => reject(new Error('Unable to open draft store.'));
-    request.onupgradeneeded = () => {
-      const database = request.result;
-      if (!database.objectStoreNames.contains(STORE_NAME)) {
-        database.createObjectStore(STORE_NAME);
-      }
-    };
-    request.onsuccess = () => resolve(request.result);
-  });
-}
+import { DRAFT_STORE_NAME, openLatticeDatabase } from './browserDatabase';
 
 export async function saveDraft(entry: CorpusEntry) {
-  const database = await openDatabase();
+  const database = await openLatticeDatabase();
   return new Promise<void>((resolve, reject) => {
-    const transaction = database.transaction(STORE_NAME, 'readwrite');
-    transaction.objectStore(STORE_NAME).put(entry, entry.id);
+    const transaction = database.transaction(DRAFT_STORE_NAME, 'readwrite');
+    transaction.objectStore(DRAFT_STORE_NAME).put(entry, entry.id);
     transaction.oncomplete = () => resolve();
     transaction.onerror = () => reject(new Error('Unable to save draft.'));
   });
 }
 
 export async function readDraft(id: string) {
-  const database = await openDatabase();
+  const database = await openLatticeDatabase();
   return new Promise<CorpusEntry | null>((resolve, reject) => {
-    const transaction = database.transaction(STORE_NAME, 'readonly');
-    const request = transaction.objectStore(STORE_NAME).get(id);
+    const transaction = database.transaction(DRAFT_STORE_NAME, 'readonly');
+    const request = transaction.objectStore(DRAFT_STORE_NAME).get(id);
     request.onsuccess = () => resolve((request.result as CorpusEntry | undefined) ?? null);
     request.onerror = () => reject(new Error('Unable to read draft.'));
   });
 }
 
 export async function clearDraft(id: string) {
-  const database = await openDatabase();
+  const database = await openLatticeDatabase();
   return new Promise<void>((resolve, reject) => {
-    const transaction = database.transaction(STORE_NAME, 'readwrite');
-    transaction.objectStore(STORE_NAME).delete(id);
+    const transaction = database.transaction(DRAFT_STORE_NAME, 'readwrite');
+    transaction.objectStore(DRAFT_STORE_NAME).delete(id);
     transaction.oncomplete = () => resolve();
     transaction.onerror = () => reject(new Error('Unable to clear draft.'));
   });

--- a/src/features/persistence/lib/workspaceStore.ts
+++ b/src/features/persistence/lib/workspaceStore.ts
@@ -1,0 +1,65 @@
+import { normalizeCorpus } from '../../corpus/lib/normalizeCorpus';
+import { validateCorpus } from '../../corpus/lib/validators';
+import type { CorpusFile } from '../../corpus/model/types';
+import type { CorpusSyncState } from '../../../pages/workspace/model/corpusSync';
+import { openLatticeDatabase, WORKSPACE_STORE_NAME } from './browserDatabase';
+
+const ACTIVE_WORKSPACE_KEY = 'active-workspace';
+
+export type PersistedWorkspaceState = {
+  corpus: CorpusFile;
+  corpusName: string;
+  selectedEntryId: string | null;
+  corpusSyncState: CorpusSyncState;
+};
+
+function isPersistedWorkspaceState(candidate: unknown): candidate is PersistedWorkspaceState {
+  if (typeof candidate !== 'object' || candidate === null) {
+    return false;
+  }
+
+  const value = candidate as Partial<PersistedWorkspaceState>;
+  return typeof value.corpusName === 'string'
+    && (typeof value.selectedEntryId === 'string' || value.selectedEntryId === null)
+    && typeof value.corpusSyncState === 'object'
+    && value.corpusSyncState !== null
+    && typeof value.corpusSyncState.baselineSnapshot === 'string'
+    && typeof value.corpusSyncState.baselineName === 'string'
+    && (value.corpusSyncState.origin === 'sample' || value.corpusSyncState.origin === 'file' || value.corpusSyncState.origin === 'download')
+    && typeof value.corpus === 'object'
+    && value.corpus !== null;
+}
+
+export async function saveWorkspaceState(state: PersistedWorkspaceState) {
+  const database = await openLatticeDatabase();
+  return new Promise<void>((resolve, reject) => {
+    const transaction = database.transaction(WORKSPACE_STORE_NAME, 'readwrite');
+    transaction.objectStore(WORKSPACE_STORE_NAME).put(state, ACTIVE_WORKSPACE_KEY);
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(new Error('Unable to save active workspace.'));
+  });
+}
+
+export async function readWorkspaceState() {
+  const database = await openLatticeDatabase();
+  return new Promise<PersistedWorkspaceState | null>((resolve, reject) => {
+    const transaction = database.transaction(WORKSPACE_STORE_NAME, 'readonly');
+    const request = transaction.objectStore(WORKSPACE_STORE_NAME).get(ACTIVE_WORKSPACE_KEY);
+    request.onsuccess = () => {
+      if (!isPersistedWorkspaceState(request.result)) {
+        resolve(null);
+        return;
+      }
+
+      try {
+        resolve({
+          ...request.result,
+          corpus: normalizeCorpus(validateCorpus(request.result.corpus)),
+        });
+      } catch {
+        resolve(null);
+      }
+    };
+    request.onerror = () => reject(new Error('Unable to restore active workspace.'));
+  });
+}

--- a/src/pages/workspace/WorkspacePage.tsx
+++ b/src/pages/workspace/WorkspacePage.tsx
@@ -2,7 +2,6 @@ import { lazy, Suspense, useMemo, useRef, useState } from 'react';
 import { AppWindow, Upload } from 'lucide-react';
 import { TopBar } from '../../app/layout/TopBar';
 import { WorkspaceLayout } from '../../app/layout/WorkspaceLayout';
-import { openArticleInNewTab } from '../../features/corpus/lib/openArticleInNewTab';
 import { StatePanel } from '../../shared/ui/StatePanel';
 import { Button } from '../../shared/ui/Button';
 import { FiltersBar } from './components/FiltersBar';
@@ -105,7 +104,7 @@ export function WorkspacePage() {
         >
           <section className="space-y-5">
             {controller.errorMessage ? (
-              <StatePanel variant="error" title="Import failed" detail={controller.errorMessage} />
+              <StatePanel variant="error" title="Workspace issue" detail={controller.errorMessage} />
             ) : null}
 
             {controller.hasUnsyncedCorpusChanges ? (
@@ -124,7 +123,14 @@ export function WorkspacePage() {
               </div>
             </div>
 
-            {dragging ? (
+            {!controller.workspaceReady ? (
+              <StatePanel centered>
+                <div>
+                  <p className="font-medium text-soft-linen">Restoring workspace</p>
+                  <p className="mt-1 text-muted">Loading the last local corpus snapshot before rebuilding search.</p>
+                </div>
+              </StatePanel>
+            ) : dragging ? (
               <StatePanel centered>
                 <div className="flex flex-col items-center gap-3">
                   <Upload className="text-teal" size={20} />
@@ -134,9 +140,7 @@ export function WorkspacePage() {
                   </div>
                 </div>
               </StatePanel>
-            ) : null}
-
-            {!dragging && controller.corpus.entries.length === 0 ? (
+            ) : controller.corpus.entries.length === 0 ? (
               <StatePanel centered>
                 <div className="flex flex-col items-center gap-3">
                   <AppWindow size={20} className="text-teal" />
@@ -185,7 +189,8 @@ export function WorkspacePage() {
         entry={controller.viewerSession.entry}
         onClose={controller.closeViewer}
         onEdit={controller.openEditArticle}
-        onOpenInNewTab={openArticleInNewTab}
+        onOpenInNewTab={controller.openArticleInNewTab}
+        onReadSessionComplete={controller.finalizeArticleReadSession}
       />
 
       <Suspense fallback={null}>

--- a/src/pages/workspace/components/ArticleViewerModal.tsx
+++ b/src/pages/workspace/components/ArticleViewerModal.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef } from 'react';
 import { ExternalLink, FilePenLine } from 'lucide-react';
+import type { ArticleReadSession } from '../../../features/corpus/lib/searchMetrics';
 import type { CorpusEntry } from '../../../features/corpus/model/types';
 import { formatAbsoluteDate } from '../../../shared/lib/dates';
 import { Button } from '../../../shared/ui/Button';
@@ -11,9 +13,77 @@ type Props = {
   onClose: () => void;
   onEdit: (entry: CorpusEntry) => void;
   onOpenInNewTab: (entry: CorpusEntry) => void;
+  onReadSessionComplete: (entry: CorpusEntry, session: ArticleReadSession) => void;
 };
 
-export function ArticleViewerModal({ entry, open, onClose, onEdit, onOpenInNewTab }: Props) {
+type ReadSessionState = {
+  entry: CorpusEntry;
+  activeStartedAt: number | null;
+  visibleDwellMs: number;
+};
+
+export function ArticleViewerModal({ entry, open, onClose, onEdit, onOpenInNewTab, onReadSessionComplete }: Props) {
+  const sessionRef = useRef<ReadSessionState | null>(null);
+
+  useEffect(() => {
+    if (!open || !entry) {
+      sessionRef.current = null;
+      return;
+    }
+
+    const session: ReadSessionState = {
+      entry,
+      activeStartedAt: null,
+      visibleDwellMs: 0,
+    };
+    sessionRef.current = session;
+
+    const isActive = () => document.visibilityState === 'visible' && document.hasFocus();
+    const resume = () => {
+      if (session.activeStartedAt !== null || !isActive()) {
+        return;
+      }
+
+      session.activeStartedAt = Date.now();
+    };
+    const pause = () => {
+      if (session.activeStartedAt === null) {
+        return;
+      }
+
+      session.visibleDwellMs += Date.now() - session.activeStartedAt;
+      session.activeStartedAt = null;
+    };
+    const finalize = () => {
+      pause();
+      onReadSessionComplete(session.entry, {
+        visibleDwellMs: session.visibleDwellMs,
+        completedAt: new Date().toISOString(),
+      });
+      sessionRef.current = null;
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        resume();
+        return;
+      }
+
+      pause();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('focus', resume);
+    window.addEventListener('blur', pause);
+    resume();
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('focus', resume);
+      window.removeEventListener('blur', pause);
+      finalize();
+    };
+  }, [entry, onReadSessionComplete, open]);
+
   if (!open || !entry) {
     return null;
   }

--- a/src/pages/workspace/useWorkspaceController.ts
+++ b/src/pages/workspace/useWorkspaceController.ts
@@ -1,13 +1,16 @@
-import { useMemo, useState } from 'react';
-import type { CorpusEntry, CorpusFile } from '../../features/corpus/model/types';
-import { sampleCorpus } from '../../features/corpus/model/sampleCorpus';
-import { buildIndex } from '../../features/search/lib/buildIndex';
-import type { SearchFilters } from '../../features/search/model/searchTypes';
-import { queryIndex } from '../../features/search/lib/queryIndex';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { exportCorpus } from '../../features/corpus/lib/exportCorpus';
-import { downloadTextFile } from '../../shared/lib/download';
 import { importCorpus } from '../../features/corpus/lib/importCorpus';
-import { setLastCorpusName, getLastCorpusName } from '../../features/persistence/lib/localState';
+import { openArticleInNewTab as launchArticleInNewTab } from '../../features/corpus/lib/openArticleInNewTab';
+import { recordArticleOpen, recordArticleReadSession, type ArticleReadSession, ARTICLE_TELEMETRY_CHANNEL, isArticleTelemetryMessage } from '../../features/corpus/lib/searchMetrics';
+import { sampleCorpus } from '../../features/corpus/model/sampleCorpus';
+import type { CorpusEntry, CorpusFile } from '../../features/corpus/model/types';
+import { getLastCorpusName, setLastCorpusName } from '../../features/persistence/lib/localState';
+import { readWorkspaceState, saveWorkspaceState } from '../../features/persistence/lib/workspaceStore';
+import { buildIndex } from '../../features/search/lib/buildIndex';
+import { queryIndex } from '../../features/search/lib/queryIndex';
+import type { SearchFilters } from '../../features/search/model/searchTypes';
+import { downloadTextFile } from '../../shared/lib/download';
 import { createId } from '../../shared/lib/ids';
 import { createCorpusSyncState, hasPendingCorpusChanges } from './model/corpusSync';
 
@@ -47,6 +50,7 @@ function createEmptyEntry(): CorpusEntry {
 
 export function useWorkspaceController() {
   const initialCorpusName = getLastCorpusName() ?? 'sample-corpus.json';
+  const [workspaceReady, setWorkspaceReady] = useState(false);
   const [corpus, setCorpus] = useState<CorpusFile>(sampleCorpus);
   const [corpusName, setCorpusName] = useState(initialCorpusName);
   const [query, setQuery] = useState('');
@@ -56,6 +60,80 @@ export function useWorkspaceController() {
   const [viewerSession, setViewerSession] = useState<ViewerSession>({ open: false, entry: null });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [corpusSyncState, setCorpusSyncState] = useState(() => createCorpusSyncState(sampleCorpus, initialCorpusName, 'sample'));
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    void readWorkspaceState()
+      .then((storedWorkspace) => {
+        if (isCancelled || !storedWorkspace) {
+          return;
+        }
+
+        setCorpus(storedWorkspace.corpus);
+        setCorpusName(storedWorkspace.corpusName);
+        setSelectedEntryId(storedWorkspace.selectedEntryId ?? storedWorkspace.corpus.entries[0]?.id ?? null);
+        setCorpusSyncState(storedWorkspace.corpusSyncState);
+        setLastCorpusName(storedWorkspace.corpusName);
+      })
+      .catch((error) => {
+        if (!isCancelled) {
+          setErrorMessage(error instanceof Error ? error.message : 'Unable to restore local workspace.');
+        }
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setWorkspaceReady(true);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!workspaceReady) {
+      return;
+    }
+
+    setLastCorpusName(corpusName);
+    void saveWorkspaceState({
+      corpus,
+      corpusName,
+      selectedEntryId,
+      corpusSyncState,
+    }).catch((error) => {
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to save active workspace.');
+    });
+  }, [corpus, corpusName, corpusSyncState, selectedEntryId, workspaceReady]);
+
+  const applyArticleOpen = useCallback((entryId: string) => {
+    setCorpus((current) => recordArticleOpen(current, entryId));
+  }, []);
+
+  const applyArticleReadSession = useCallback((entryId: string, session: ArticleReadSession) => {
+    setCorpus((current) => recordArticleReadSession(current, entryId, session));
+  }, []);
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') {
+      return;
+    }
+
+    const channel = new BroadcastChannel(ARTICLE_TELEMETRY_CHANNEL);
+    channel.onmessage = (event: MessageEvent<unknown>) => {
+      if (!isArticleTelemetryMessage(event.data) || event.data.corpusName !== corpusName) {
+        return;
+      }
+
+      applyArticleReadSession(event.data.entryId, event.data.session);
+    };
+
+    return () => {
+      channel.close();
+    };
+  }, [applyArticleReadSession, corpusName]);
 
   const searchIndex = useMemo(() => buildIndex(corpus.entries), [corpus.entries]);
   const results = useMemo(() => queryIndex(searchIndex, query, filters), [filters, query, searchIndex]);
@@ -67,7 +145,6 @@ export function useWorkspaceController() {
     return corpus.entries.find((entry) => entry.id === selectedEntryId) ?? results[0]?.entry ?? null;
   }, [corpus.entries, results, selectedEntryId]);
   const hasUnsyncedCorpusChanges = useMemo(() => hasPendingCorpusChanges(corpusSyncState, corpus), [corpus, corpusSyncState]);
-
 
   function updateFilters(next: Partial<SearchFilters>) {
     setFilters((current) => ({ ...current, ...next }));
@@ -83,9 +160,19 @@ export function useWorkspaceController() {
   }
 
   function openArticle(entry: CorpusEntry) {
+    applyArticleOpen(entry.id);
     setSelectedEntryId(entry.id);
     setViewerSession({ open: true, entry });
   }
+
+  const openArticleInNewTab = useCallback((entry: CorpusEntry) => {
+    applyArticleOpen(entry.id);
+    launchArticleInNewTab(entry, corpusName);
+  }, [applyArticleOpen, corpusName]);
+
+  const finalizeArticleReadSession = useCallback((entry: CorpusEntry, session: ArticleReadSession) => {
+    applyArticleReadSession(entry.id, session);
+  }, [applyArticleReadSession]);
 
   function openEditArticle(entry: CorpusEntry) {
     setViewerSession({ open: false, entry: null });
@@ -114,8 +201,15 @@ export function useWorkspaceController() {
 
       didDelete = true;
       nextSelectedEntryId = selectedEntryId === entryId ? (remainingEntries[0]?.id ?? null) : (selectedEntryId ?? remainingEntries[0]?.id ?? null);
+      const { [entryId]: _deletedMetrics, ...remainingMetrics } = current.searchMetrics.entries;
 
-      return { ...current, entries: remainingEntries };
+      return {
+        ...current,
+        entries: remainingEntries,
+        searchMetrics: {
+          entries: remainingMetrics,
+        },
+      };
     });
 
     if (!didDelete) {
@@ -161,7 +255,6 @@ export function useWorkspaceController() {
     }
   }
 
-
   function saveEntry(nextEntry: CorpusEntry) {
     setCorpus((current) => {
       const exists = current.entries.some((entry) => entry.id === nextEntry.id);
@@ -203,6 +296,7 @@ export function useWorkspaceController() {
   }
 
   return {
+    workspaceReady,
     corpus,
     corpusName,
     query,
@@ -215,6 +309,8 @@ export function useWorkspaceController() {
     setSelectedEntryId,
     viewerSession,
     openArticle,
+    openArticleInNewTab,
+    finalizeArticleReadSession,
     closeViewer,
     editorSession,
     openNewArticle,


### PR DESCRIPTION
## Summary
- bump corpus schema to `1.2` and add corpus-level `searchMetrics` normalization/validation
- track article opens plus visibility-aware dwell sessions in the modal and new-tab reader flows
- autosave the active corpus workspace to IndexedDB so learned metrics survive refresh and remain exportable in JSON

## Why
This is the telemetry/persistence foundation for behavior-aware search ranking. It keeps learned state inside each user's portable corpus while preserving lexical MiniSearch behavior for now.

## Scope boundary
This PR does **not** change search ordering yet.
There is currently **no behavioral boost or de-boost applied at all** in this branch, so there is no uncapped ranking effect shipping here.

The next PR will consume these metrics inside `queryIndex`, and that PR will include hard caps so behavior can only nudge rankings within bounded limits.

## What changed
- added `searchMetrics.entries[entryId]` to the corpus model with:
  - `openCount`
  - `qualifiedViewCount`
  - `shortAbandonCount`
  - `totalQualifiedDwellSeconds`
  - `longViewCount`
  - `lastViewedAt`
- normalized legacy `1.1` corpora into `1.2` with empty metrics
- added session classification thresholds for:
  - short abandon `< 8s`
  - qualified view `>= 10s`
  - long view `>= 60s`
- instrumented modal reads and new-tab reads with visibility-aware dwell tracking
- persisted the active workspace snapshot in IndexedDB and restore it on reload
- kept current search ranking behavior unchanged in this PR

## Verification
- `npm run check`
- `npm run build`
- manual browser verification at `http://127.0.0.1:5173/`
  - opening an article immediately marks the workspace as changed
  - reloading preserves the changed workspace via IndexedDB autosave

## Follow-up
A later PR can safely consume these metrics inside `queryIndex` to add bounded boost/de-boost reranking without changing the storage model again.
